### PR TITLE
Use native `Object.assign`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const assign = require('object-assign');
 const stringWidth = require('string-width');
 const stripAnsi = require('strip-ansi');
 
@@ -55,7 +54,7 @@ function toString(arr) {
 
 function columns(values, options) {
 	values = concat.apply([], values);
-	options = assign({}, defaults, options);
+	options = Object.assign({}, defaults, options);
 
 	let cells = values
 		.filter(Boolean)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "homepage": "https://github.com/shannonmoeller/cli-columns",
   "dependencies": {
-    "object-assign": "^4.1.1",
     "string-width": "^2.0.0",
     "strip-ansi": "^3.0.1"
   },


### PR DESCRIPTION
It's native in all versions of `node` currently supported by `cli-columns`.